### PR TITLE
Changed from exec to spawn when executing WMIC in Windows.

### DIFF
--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -77,7 +77,7 @@ const finders = {
   win32 (cond) {
     return new Promise((resolve, reject) => {
       const cmd = 'WMIC path win32_process get Name,Processid,ParentProcessId,Commandline'
-      const lines = [];
+      const lines = []
 
       const proc = utils.spawn('cmd', ['/c', cmd], { detached: false })
       proc.stdout.on('data', data => {
@@ -87,7 +87,6 @@ const finders = {
         if (code !== 0) {
           reject('Command \'' + cmd + '\' terminated with code: ' + code)
         }
-        const result = lines.join('\n')
         let list = utils.parseTable(lines.join('\n'))
           .filter(row => {
             if ('pid' in cond) {
@@ -97,16 +96,15 @@ const finders = {
             }
           })
           .map(row => ({
-              pid: row.ProcessId,
-              ppid: row.ParentProcessId,
-              uid: null,
-              gid: null,
-              name: row.Name,
-              cmd: row.CommandLine
-            })
-          )
+            pid: row.ProcessId,
+            ppid: row.ParentProcessId,
+            uid: null,
+            gid: null,
+            name: row.Name,
+            cmd: row.CommandLine
+          }))
         resolve(list)
-      })  
+      })
     })
   }
 }

--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -76,40 +76,37 @@ const finders = {
   freebsd: 'darwin',
   win32 (cond) {
     return new Promise((resolve, reject) => {
-      let cmd = 'WMIC path win32_process get Name,Processid,ParentProcessId,Commandline'
+      const cmd = 'WMIC path win32_process get Name,Processid,ParentProcessId,Commandline'
+      const lines = [];
 
-      utils.exec(cmd, function (err, stdout, stderr) {
-        if (err) {
-          reject(err)
-        } else {
-          err = stderr.toString().trim()
-          if (err) {
-            reject(err)
-            return
-          }
-
-          let list = utils.parseTable(stdout.toString())
-            .filter(row => {
-              if ('pid' in cond) {
-                return row.ProcessId === String(cond.pid)
-              } else {
-                return matchName(row.CommandLine, cond.name)
-              }
-            })
-            .map(row => {
-              return {
-                pid: row.ProcessId,
-                ppid: row.ParentProcessId,
-                uid: null,
-                gid: null,
-                name: row.Name,
-                cmd: row.CommandLine
-              }
-            })
-
-          resolve(list)
-        }
+      const proc = utils.spawn('cmd', ['/c', cmd], { detached: false })
+      proc.stdout.on('data', data => {
+        lines.push(data.toString())
       })
+      proc.on('close', code => {
+        if (code !== 0) {
+          reject('Command \'' + cmd + '\' terminated with code: ' + code)
+        }
+        const result = lines.join('\n')
+        let list = utils.parseTable(lines.join('\n'))
+          .filter(row => {
+            if ('pid' in cond) {
+              return row.ProcessId === String(cond.pid)
+            } else {
+              return matchName(row.CommandLine, cond.name)
+            }
+          })
+          .map(row => ({
+              pid: row.ProcessId,
+              ppid: row.ParentProcessId,
+              uid: null,
+              gid: null,
+              name: row.Name,
+              cmd: row.CommandLine
+            })
+          )
+        resolve(list)
+      })  
     })
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,12 @@ const utils = {
     }, callback)
   },
   /**
+   * spawn command
+   */
+  spawn (cmd, args, options) {
+    return cp.spawn(cmd, args, options);
+  },
+  /**
    * Strip top lines of text
    *
    * @param  {String} text

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,7 @@ const utils = {
    * spawn command
    */
   spawn (cmd, args, options) {
-    return cp.spawn(cmd, args, options);
+    return cp.spawn(cmd, args, options)
   },
   /**
    * Strip top lines of text


### PR DESCRIPTION
Fix #5 'stdout maxBuffer exceeded.' on Windows, changed WMIC execution from 'exec' to 'spawn' and process the stdout stream instead of the entire stdout output in one go.