### PR TITLE
Return from rejection

### DIFF
--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -85,7 +85,7 @@ const finders = {
       })
       proc.on('close', code => {
         if (code !== 0) {
-          reject('Command \'' + cmd + '\' terminated with code: ' + code)
+          return reject('Command \'' + cmd + '\' terminated with code: ' + code)
         }
         let list = utils.parseTable(lines.join('\n'))
           .filter(row => {


### PR DESCRIPTION
There was a bug introduced in the last win32 spawning change, where if there was an error running the spawn process,
the Promise would be rejected, but processing would continue causing cascading errors.

This change simply returns the reject so we do not continue processing.