### PR TITLE
Fixes for Windows PID 0

### DIFF
--- a/lib/find_pid.js
+++ b/lib/find_pid.js
@@ -126,7 +126,7 @@ const finders = {
             }
           })
 
-          if (columns && columns[1].length) {
+          if (columns && columns[1].length && columns[1] > 0) {
             resolve(parseInt(columns[1], 10))
           } else {
             reject(`pid of port (${port}) not found`)

--- a/lib/find_pid.js
+++ b/lib/find_pid.js
@@ -126,7 +126,7 @@ const finders = {
             }
           })
 
-          if (columns && columns[1].length && columns[1] > 0) {
+          if (columns && columns[1].length && parseInt(columns[1], 10) > 0) {
             resolve(parseInt(columns[1], 10))
           } else {
             reject(`pid of port (${port}) not found`)

--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -96,7 +96,7 @@ const finders = {
         }
         let list = utils.parseTable(lines.join('\n'))
           .filter(row => {
-            if (cond.pid) {
+            if ('pid' in cond) {
               return row.ProcessId === String(cond.pid)
             } else if (cond.name) {
               if (cond.strict) {


### PR DESCRIPTION
I came across this issue when calling `find("port", 443)` right after I quit a process on Windows. The result was that it did return all processes. 

The function `find_pid` did return PID 0 (zero). Which resulted `find_process` to return all processes because it did check for `Falsey` on `cond.pid` instead of checking if it exists.

**Note**
On Windows, PID 0 is System Idle Process, which is not really a process.