### PR TITLE
Allow port option for non-root user on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,6 @@ The resolved value of promise is an array list of process (`[]` means it may be 
 }, ...]
 ```
 
-### Notice
-
-Since find-process use `netstat` to find process of specified port internally, you might need `sudo` to run with find-process on Linux platform.
-
-If you use find-process in command line without sudo, the find-process will prompt a sudo password message, the find process will continue after you enter the right password.
-
-*User on Windows/Mac OSX has no such problem.*
-
 ## Example
 
 Find process which is listening port 80.

--- a/lib/find_pid.js
+++ b/lib/find_pid.js
@@ -61,22 +61,17 @@ const finders = {
   freebsd: 'darwin',
   sunos: 'darwin',
   linux (port) {
-    return new Promise((resolve, reject) => {
-      // netstat -p need sudo to run
+    return new Promise((resolve, reject) => {      
       let cmd = 'netstat -tunlp'
-
-      if (process.getuid() > 0) {
-        throw new Error('netstat need root to run')
-      }
 
       utils.exec(cmd, function (err, stdout, stderr) {
         if (err) {
           reject(err)
         } else {
-          err = stderr.toString().trim()
-          if (err) {
-            reject(err)
-            return
+          const warn = stderr.toString().trim()
+          if (warn) {
+            // netstat -p ouputs warning if user is no-root
+            console.warn(warn);
           }
 
           // replace header

--- a/lib/find_pid.js
+++ b/lib/find_pid.js
@@ -61,7 +61,7 @@ const finders = {
   freebsd: 'darwin',
   sunos: 'darwin',
   linux (port) {
-    return new Promise((resolve, reject) => {      
+    return new Promise((resolve, reject) => {
       let cmd = 'netstat -tunlp'
 
       utils.exec(cmd, function (err, stdout, stderr) {
@@ -71,7 +71,7 @@ const finders = {
           const warn = stderr.toString().trim()
           if (warn) {
             // netstat -p ouputs warning if user is no-root
-            console.warn(warn);
+            console.warn(warn)
           }
 
           // replace header


### PR DESCRIPTION
Since `netstat -tunlp` command does not need sudo (although it only shows current-user's processes), it's better to allow `--port` for non-root user on linux.
(I tested netstat 1.42 on centos5 and debian8, netstat 2.10-alpha on ubuntu18)

I removed uid check and update the code to show netstat warning in stderr instead.

run as non-root

```
$ node bin/find-process.js -p 8000 
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
Found 1 process

[python]
pid: 23125
cmd: python -m http.server

$ node bin/find-process.js -p 800
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
No process found
```

run as root 

```
$ sudo node bin/find-process.js -p 8000 
Found 1 process

[python]
pid: 23125
cmd: python -m http.server

$ sudo node bin/find-process.js -p 80
No process found
```