### PR TITLE
Update README to indicate strict mode checks against port, pid, and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Promise<Array> find(type, value, [strict])
 
 - `type` the type of find, support: *port|pid|name*
 - `value` the value of type, can be RegExp if type is *name*
-- `strict` the optional strict mode is for checking *name* exactly matches the give one. (on Windows, `.exe` can be omitted)
+- `strict` the optional strict mode is for checking *port*, *pid*, or *name* exactly matches the given one. (on Windows, `.exe` can be omitted)
 
 **Return**
 


### PR DESCRIPTION
Per [this change](https://github.com/yibn2008/find-process/commit/c65c3152813353531f826ef7d9fffd8f363cd7df), `strict` mode applies to not only `name`, but also to `pid` and `port`. 