### PR TITLE
fix: fix long windows lines

### DIFF
--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -131,13 +131,13 @@ const finders = {
         if (code !== 0) {
           return reject(new Error('Command \'' + cmd + '\' terminated with code: ' + code))
         }
-        let list = utils.parseTable(lines.join('\n'))
+        let list = utils.parseTable(lines.join(''))
           .filter(row => {
             if ('pid' in cond) {
               return row.ProcessId === String(cond.pid)
             } else if (cond.name) {
               if (cond.strict) {
-                return row.Name === cond.name || (row.Name.endsWith('.exe') && row.Name.slice(0, -4) === cond.name)
+                return row.Name === cond.name || (row.Name && row.Name.endsWith('.exe') && row.Name.slice(0, -4) === cond.name)
               } else {
                 // fix #9
                 return matchName(row.CommandLine || row.Name, cond.name)


### PR DESCRIPTION
This fix resolves the problems with long lines in windows as data in buffer is not always containing a full line.

Closes #29 