### PR TITLE
Add check for System32 in path before spawning cmd (fix issue #23)

### DIFF
--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -123,7 +123,8 @@ const finders = {
       const cmd = 'WMIC path win32_process get Name,Processid,ParentProcessId,Commandline,ExecutablePath'
       const lines = []
 
-      const proc = utils.spawn('cmd', ['/c', cmd], { detached: false, windowsHide: true })
+      const spawnCmd = process.env.path && process.env.path.includes("C:\\Windows\\System32") ? "cmd" : "C:\\Windows\\System32\\cmd.exe";
+      const proc = utils.spawn(spawnCmd, ['/c', cmd], { detached: false, windowsHide: true })
       proc.stdout.on('data', data => {
         lines.push(data.toString())
       })

--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -123,7 +123,7 @@ const finders = {
       const cmd = 'WMIC path win32_process get Name,Processid,ParentProcessId,Commandline,ExecutablePath'
       const lines = []
 
-      const spawnCmd = process.env.path && process.env.path.includes("C:\\Windows\\System32") ? "cmd" : "C:\\Windows\\System32\\cmd.exe";
+      const spawnCmd = process.env.path && process.env.path.includes('C:\\Windows\\System32') ? 'cmd' : 'C:\\Windows\\System32\\cmd.exe'
       const proc = utils.spawn(spawnCmd, ['/c', cmd], { detached: false, windowsHide: true })
       proc.stdout.on('data', data => {
         lines.push(data.toString())


### PR DESCRIPTION
Fixes [this](https://github.com/yibn2008/find-process/issues/23) even though it affects a very small user base.