### PR TITLE
Add logging parameter to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,16 @@ find('pid', 12345)
 ## Synopsis
 
 ```
-Promise<Array> find(type, value, [strict])
+Promise<Array> find(type, value, [options])
 ```
 
 **Arguments**
 
 - `type` the type of find, support: *port|pid|name*
 - `value` the value of type, can be RegExp if type is *name*
-- `strict` the optional strict mode is for checking *port*, *pid*, or *name* exactly matches the given one. (on Windows, `.exe` can be omitted)
+- `options` this can either be the *object* described below or *boolean* to just set strict mode
+  - `options.strict` the optional strict mode is for checking *port*, *pid*, or *name* exactly matches the given one. (on Windows, `.exe` can be omitted)
+  - `options.logLevel` set the logging level to [`trace|debug|info|warn|error`](https://github.com/pimterry/loglevel#documentation). In practice this lets you silence a netstat warning on Linux.
 
 **Return**
 
@@ -139,6 +141,16 @@ find('name', 'nginx', true)
   });
 ```
 
+Find all nginx processes on Linux without logging a warning when run as a user who isn't root.
+
+```javascript
+const find = require('find-process');
+
+find('name', 'nginx', {strict: true, logLevel: 'error'})
+  .then(function (list) {
+    console.log('there are %s nginx process(es)', list.length);
+  });
+```
 ## Contributing
 
 We're welcome to receive Pull Request of bugfix or new feature, but please check the list before sending PR:

--- a/bin/find-process.js
+++ b/bin/find-process.js
@@ -4,7 +4,7 @@
 
 const program = require('commander')
 const chalk = require('chalk')
-const debug = require('debug')('find-process')
+const log = require('loglevel').getLogger('find-process')
 const find = require('..')
 const pkg = require('../package.json')
 
@@ -54,7 +54,7 @@ if (opts.port) {
   type = opts.type
 }
 
-debug('find process by: type = %s, keyword = "%s"', type, keyword)
+log.debug('find process by: type = %s, keyword = "%s"', type, keyword)
 
 find(type, keyword)
   .then(list => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,30 @@
-declare function find(type: "name" | "pid" | "port", value: string | number | RegExp, strict?: boolean): Promise<{
+// https://github.com/pimterry/loglevel/blob/f5a642299bf77a81118d68766a168c9568ecd21b/index.d.ts#L14-L38
+interface LogLevel {
+    TRACE: 0;
+    DEBUG: 1;
+    INFO: 2;
+    WARN: 3;
+    ERROR: 4;
+    SILENT: 5;
+}
+
+type LogLevelNumbers = LogLevel[keyof LogLevel];
+
+type LogLevelDesc = LogLevelNumbers
+    | 'trace'
+    | 'debug'
+    | 'info'
+    | 'warn'
+    | 'error'
+    | 'silent'
+    | keyof LogLevel;
+
+declare type Options = {
+    strict?: boolean;
+    logLevel?: LogLevelDesc;
+}
+
+declare function find(type: "name" | "pid" | "port", value: string | number | RegExp, strict?: boolean | Option): Promise<{
     pid: number;
     ppid?: number;
     uid?: number;

--- a/lib/find.js
+++ b/lib/find.js
@@ -9,27 +9,28 @@
 
 const findPid = require('./find_pid')
 const findProcess = require('./find_process')
+const log = require('./logger')
 
 const findBy = {
-  port (port, strict) {
-    return findPid(port, strict)
+  port (port, config) {
+    return findPid(port)
       .then(pid => {
-        return findBy.pid(pid, strict)
+        return findBy.pid(pid, config)
       }, () => {
         // return empty array when pid not found
         return []
       })
   },
-  pid (pid, strict) {
+  pid (pid, config) {
     return findProcess({
       pid: pid,
-      strict
+      config
     })
   },
-  name (name, strict) {
+  name (name, config) {
     return findProcess({
       name: name,
-      strict
+      config
     })
   }
 }
@@ -48,11 +49,19 @@ const findBy = {
  *
  * If no process found, resolve process with empty array (only reject when error occured)
  *
- * @param  {String} by condition: port/pid/name ...
+ * @param {String} by condition: port/pid/name ...
  * @param {Mixed} condition value
+ * @param {Boolean|Option}
  * @return {Promise}
  */
-function find (by, value, strict) {
+function find (by, value, options) {
+  const config = Object.assign({
+    logLevel: 'warn',
+    strict: typeof options === 'boolean' ? options : false
+  }, options)
+
+  log.setLevel(config.logLevel)
+
   return new Promise((resolve, reject) => {
     if (!(by in findBy)) {
       reject(new Error(`do not support find by "${by}"`))
@@ -63,7 +72,7 @@ function find (by, value, strict) {
       } else if (by === 'port' && !isNumber) {
         reject(new Error('port must be a number'))
       } else {
-        findBy[by](value, strict).then(resolve, reject)
+        findBy[by](value, config).then(resolve, reject)
       }
     }
   })

--- a/lib/find_pid.js
+++ b/lib/find_pid.js
@@ -12,6 +12,7 @@
 const os = require('os')
 const fs = require('fs')
 const utils = require('./utils')
+const log = require('./logger')
 
 const ensureDir = (path) => new Promise((resolve, reject) => {
   if (fs.existsSync(path)) {
@@ -71,7 +72,7 @@ const finders = {
           const warn = stderr.toString().trim()
           if (warn) {
             // netstat -p ouputs warning if user is no-root
-            console.warn(warn)
+            log.warn(warn)
           }
 
           // replace header

--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -106,7 +106,7 @@ const finders = {
             }
           })
 
-          if (cond.strict && cond.name) {
+          if (cond.config.strict && cond.name) {
             list = list.filter(item => item.name === cond.name)
           }
 
@@ -137,7 +137,7 @@ const finders = {
               return row.ProcessId === String(cond.pid)
             } else if (cond.name) {
               const rowName = row.Name || '' // fix #40
-              if (cond.strict) {
+              if (cond.config.strict) {
                 return rowName === cond.name || (rowName.endsWith('.exe') && rowName.slice(0, -4) === cond.name)
               } else {
                 // fix #9
@@ -206,7 +206,7 @@ const finders = {
             }
           })
 
-          if (cond.strict && cond.name) {
+          if (cond.config.strict && cond.name) {
             list = list.filter(item => item.name === cond.name)
           }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const log = require('loglevel')
+
+module.exports = log

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "chalk": "^4.0.0",
     "commander": "^5.1.0",
-    "debug": "^4.1.1"
+    "loglevel": "^1.8.0"
   },
   "devDependencies": {
     "mocha": "^7.2.0",


### PR DESCRIPTION
## Summary
On some Linux systems `netstat` will output a warning if not run as root.
This API gives API users more control over showing this warning:

```javascript
const processes = await find('port', 80, { logLevel: 'error' });
```

This change is backwards compatible:

```javascript
// Equivalent
await find('name', 'nginx', true),
await find('name', 'nginx', { strict: true }),

// Equivalent
await find('name', 'nginx'),
await find('name', 'nginx', false),
await find('name', 'nginx', { strict: false}),
```

## Testing
```
$ npm run lint

> find-process@1.4.7 lint
> standard --fix && npm-ensure -t deps

==> check dependencies
✓ OK


$ npm run test

> find-process@1.4.7 test
> mocha test/*.test.js && standard



  Find process test
    ✓ should find process of listenning port (52ms)
    ✓ should find process of pid
    ✓ should find process list matched given name (108ms)
    ✓ should resolve empty array when pid not exists


  4 passing (223ms)

$ ./bin/find-process.js --help
Usage: find-process [options] <keyword>

Options:
  -V, --version      output the version number
  -t, --type <type>  find process by keyword type (pid|port|name)
  -p, --port         find process by port
  -h, --help         display help for command

  Examples:

    $ find-process node          # find by name "node"
    $ find-process 111           # find by pid "111"
    $ find-process -p 80         # find by port "80"
    $ find-process -t port 80    # find by port "80"

$ (nc -l 8080&; ./bin/find-process.js -p 8080)
Found 1 process

[nc]
pid: 69829
cmd: nc -l 8080
```

fix #59