### PR TITLE
Switched to PS Core with a legacy PS fallback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare type Options = {
     logLevel?: LogLevelDesc;
 }
 
-declare function find(type: "name" | "pid" | "port", value: string | number | RegExp, strict?: boolean | Option): Promise<{
+declare function find(type: "name" | "pid" | "port", value: string | number | RegExp, strict?: boolean | Options): Promise<{
     pid: number;
     ppid?: number;
     uid?: number;

--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -119,11 +119,16 @@ const finders = {
   sunos: 'darwin',
   freebsd: 'darwin',
   win32 (cond) {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       const cmd = 'Get-CimInstance -className win32_process | select Name,ProcessId,ParentProcessId,CommandLine,ExecutablePath'
       const lines = []
 
-      const proc = utils.spawn('powershell.exe', ['/c', cmd], { detached: false, windowsHide: true })
+      const pwshBinary = await utils.findFirstInPath('pwsh.exe') || await utils.findFirstInPath('powershell.exe')
+      if(!pwshBinary) {
+        throw new Error('No powershell binary was found')
+      }
+
+      const proc = utils.spawn(pwshBinary, ['/c', cmd], { detached: false, windowsHide: true })
       proc.stdout.on('data', data => {
         lines.push(data.toString())
       })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,8 @@
 'use strict'
 
 const cp = require('child_process')
+const path = require('path')
+const fs = require('fs')
 
 const UNIT_MB = 1024 * 1024
 
@@ -26,6 +28,20 @@ const utils = {
    */
   spawn (cmd, args, options) {
     return cp.spawn(cmd, args, options)
+  },
+  async findFirstInPath(executable) {
+    const paths = process.env.path.split(process.platform === 'win32' ? ';' : ':').filter(f => f.trim())
+  
+    for (const i in paths) {
+      try {
+        const search = path.join(paths[i], executable)
+        await fs.promises.lstat(search)
+        return search
+      }
+      catch (ex) { continue }
+    }
+  
+    return null
   },
   /**
    * Strip top lines of text
@@ -134,7 +150,7 @@ const utils = {
    * @return {Array}
    */
   parseTable (data) {
-    const lines = data.split(/(\r\n\r\n|\r\n\n|\n\r\n)|\n\n/).filter(line => {
+    const lines = data.replace(/\x1b\[[0-9;]*m/gm, '').split(/(\r\n\r\n|\r\n\n|\n\r\n)|\n\n/).filter(line => {
       return line.trim().length > 0
     }).map((e) => e.split(/(\r\n|\n|\r)/).filter(line => line.trim().length > 0))
 


### PR DESCRIPTION
PSCore has a faster load time and offers the same functionality required for find-process over the legacy .NET Framework based versions.

This change is to switched the PowerShell spawning to prioritize PSCore (pwsh.exe) over the legacy PS versions (powershell.exe) by manually performing the binary lookup to pass in to the `utils.spawn` command before executing. If the pwsh.exe executable exists, it will execute that, and if not it will attempt to find a powershell.exe executable instead. If none is found, an error is thrown.

Milage may vary, but with my local testing I see on average ~450ms of a speed reduction. (The PSCore version taking aprox ~450ms to run, PS Legacy taking ~900ms).