### PR TITLE
fix: add missing error handler to spawn

### DIFF
--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -127,6 +127,9 @@ const finders = {
       proc.stdout.on('data', data => {
         lines.push(data.toString())
       })
+      proc.on('error', err => {
+        reject(new Error('Command \'' + cmd + '\' failed with reason: ' + err.toString()))
+      })
       proc.on('close', code => {
         if (code !== 0) {
           return reject(new Error('Command \'' + cmd + '\' terminated with code: ' + code))


### PR DESCRIPTION
If spawn is unable to start `powershell.exe`, it emits an 'error' which is currently unhandled so will cause the application to crash.

Instead this will handle that error and propogate it out to the user as a promise rejection, which is possible to handle