### PR TITLE
[FID-6892] fix: do not crash when parsing process info which contains \n\n on windows

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -134,8 +134,8 @@ const utils = {
    * @return {Array}
    */
   parseTable (data) {
-    const lines = data.split(/(\r\n\r\n|\r\n\n|\n\r\n)|\n\n/).filter(line => {
-      return line.trim().length > 0
+    const lines = data.split(/(\r\n\r\n|\r\n\n|\n\r\n|\n\n)/).filter(line => {
+      return line?.trim().length > 0
     }).map((e) => e.split(/(\r\n|\n|\r)/).filter(line => line.trim().length > 0))
 
     // Join multi-ligne value


### PR DESCRIPTION
Since regex capture groups are always returned in the result, in some cases, when processes contained \n\n, there were undefined elements in the data, which crashed the node process when trim() was called. 

Fix the capture group to contain \n\n as well as 