### PR TITLE
fix: prevent windows from throwing an error with a mixture of carriage returns

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -134,7 +134,7 @@ const utils = {
    * @return {Array}
    */
   parseTable (data) {
-    const lines = data.split(/(\r\n\r\n|\r\n\n|\n\r\n)|\n\n/).filter(line => {
+    const lines = data.split(/(\r\n\r\n|\r\n\n|\n\r\n|\n\n)/).filter(line => {
       return line.trim().length > 0
     }).map((e) => e.split(/(\r\n|\n|\r)/).filter(line => line.trim().length > 0))
 


### PR DESCRIPTION
We were receiving errors of the form:

```
TypeError: Cannot read properties of undefined (reading 'trim')
```

We traced it down to [this line](https://github.com/yibn2008/find-process/blob/master/lib/utils.js#L138).

From [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split):

```
If separator is a regular expression with capturing groups, then each time separator matches, the captured groups (including any undefined results) are spliced into the output array.
```

The fix for this is to just use one single capture group so we don't have capture groups with undefined results.

