### PR TITLE
fix: change powershell output encoding to UTF-8

### DIFF
--- a/lib/find_process.js
+++ b/lib/find_process.js
@@ -120,7 +120,7 @@ const finders = {
   freebsd: 'darwin',
   win32 (cond) {
     return new Promise((resolve, reject) => {
-      const cmd = 'Get-CimInstance -className win32_process | select Name,ProcessId,ParentProcessId,CommandLine,ExecutablePath'
+      const cmd = '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-CimInstance -className win32_process | select Name,ProcessId,ParentProcessId,CommandLine,ExecutablePath'
       const lines = []
 
       const proc = utils.spawn('powershell.exe', ['/c', cmd], { detached: false, windowsHide: true })


### PR DESCRIPTION
This will fix broken non-ASCII characters in `bin`, `name` and `cmd` fields.