### PR TITLE
Fix pid-for-port detection on newer macOS broken by a netstat change

### DIFF
--- a/lib/find_pid.js
+++ b/lib/find_pid.js
@@ -37,9 +37,21 @@ const finders = {
             return
           }
 
-          // replace header
-          const data = utils.stripLine(stdout.toString(), 2)
-          const found = utils.extractColumns(data, [0, 3, 8], 10)
+          // Drop group header, e.g. "Active Internet connections"
+          const table = utils.stripLine(stdout.toString(), 1)
+          // Get the next line with the column headers
+          const headers = table.slice(0, table.indexOf('\n'))
+          // Drop the header line to get the table body
+          const body = utils.stripLine(table, 1)
+
+          // In macOS >=Sequoia, columns include `rxbytes` and `txbytes`, which
+          // shifts the PID column to index 10. Detect this with a search
+          // for rxbytes. (Parsing the headers more robustly isn't possible
+          // because some colmn names contain spaces, and others are only separated
+          // by a single space.)
+          const pidColumn = headers.indexOf('rxbytes') >= 0 ? 10 : 8
+
+          const found = utils.extractColumns(body, [0, 3, pidColumn], 10)
             .filter(row => {
               return !!String(row[0]).match(/^(udp|tcp)/)
             })


### PR DESCRIPTION
## Problem
`find-process` doesn't work on the latest version of macOS with a `port` input, because two extra columns have been introduced to the output of `netstat -anv` before `pid`. `rhiwat` (another number) is returned instead of `pid`, so `find-process` either fails or returns information about a random process.

## `netstat` change

*Note: I'm not sure **exactly** when this changed and can't find any public information on it - I have the newer output in macos 15.1.1.*

### Sonoma 
```
 netstat -anv -p TCP | head -n2
Active Internet connections (including servers)
Proto Recv-Q Send-Q  Local Address          Foreign Address        (State)      rhiwat  shiwat    pid   epid state  options           gencnt    flags   flags1 usecnt rtncnt fltrs
```

### Sequoia
 - Note `rxbytes` and `txbytes` are new
```
 netstat -anv -p TCP | head -n2
Active Internet connections (including servers)
Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)        rxbytes    txbytes  rhiwat  shiwat    pid   epid state  options           gencnt    flags   flags1 usecnt rtncnt fltrs
```

## Proposed change
I'm not sure whether it's safe to link this change to a specific `os.version()`, I'm not sure what precisely that version would be, and `os.version()`/`uname` itself is not trivial to parse.

Instead this uses a simple heuristic - if the header line contains `rxbytes`, we assume `pid` is at index 10, or 8 otherwise.

## Before
```
pnpm test          

> find-process@1.4.10 test /Users/robhogan/workspace/find-process
> mocha test/*.test.js && standard



  Find process test
    ✔ should run the bin/find-process.js (118ms)
    1) should find process of listenning port
    ✔ should find process of pid
    ✔ should find process list matched given name (182ms)
    ✔ should resolve empty array when pid not exists (88ms)


  4 passing (521ms)
  1 failing

  1) Find process test
       should find process of listenning port:

      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert(list.length === 1)

      + expected - actual

      -false
      +true
      
      at /Users/robhogan/workspace/find-process/test/find.test.js:33:13



 ELIFECYCLE  Test failed. See above for more details.
```

## After
```
pnpm test                                                   

> find-process@1.4.10 test /Users/robhogan/workspace/find-process
> mocha test/*.test.js && standard



  Find process test
    ✔ should run the bin/find-process.js (161ms)
    ✔ should find process of listenning port (109ms)
    ✔ should find process of pid
    ✔ should find process list matched given name (195ms)
    ✔ should resolve empty array when pid not exists (56ms)


  5 passing (559ms)
```

(I've opened a similar PR at https://github.com/sindresorhus/pid-port/pull/12)