### PR TITLE
fix: add missing regexp type when passing regexp as value

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ function find(type: 'port' | 'pid' | 'name', value: string | number, options?: F
 - `type` - The type of search, supports: `'port' | 'pid' | 'name'`
 - `value` - The value to search for. Can be RegExp if type is `'name'`
 - `options` - Optional configuration object or boolean for strict mode
-  - `options.strict` - Optional strict mode for exact matching of port, pid, or name (on Windows, `.exe` can be omitted)
+  - `options.strict` - Optional strict mode for exact matching of name (on Windows, `.exe` can be omitted)
   - `options.logLevel` - Set logging level to `'trace' | 'debug' | 'info' | 'warn' | 'error'`. Useful for silencing netstat warnings on Linux
   - `options.skipSelf` - Skip the current process when searching by name
 

--- a/src/find_process.ts
+++ b/src/find_process.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import utils from './utils'
 import { ProcessInfo, FindCondition, PlatformFinder } from './types'
 
-function matchName(text: string, name: string): boolean {
+function matchName(text: string, name: string | RegExp): boolean {
   if (!name) {
     return true
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface FindConfig {
  */
 export interface FindCondition {
   pid?: number
-  name?: string
+  name?: string | RegExp
   config: FindConfig
   skipSelf?: boolean
 }

--- a/test/find.test.ts
+++ b/test/find.test.ts
@@ -72,6 +72,24 @@ describe('Find process test', function () {
       });
   })
 
+    it('should find process list matched given regexp', function (done) {
+    const file = path.join(__dirname, 'fixtures/child_process.js')
+    const cps: ChildProcessWithoutNullStreams = cp.spawn(process.execPath, [file, 'AAABBBCCC']);
+
+    (find as any)('name', /A{2,3}B{2,3}C{2,3}/gi)
+      .then(function (list: any[]) {
+        cps.kill()
+
+        assert(list.length === 1)
+        assert.equal(cps.pid, list[0].pid)
+        done()
+      }, function (err: any) {
+        cps.kill()
+
+        done(err)
+      })
+  })
+
   it('should resolve empty array when pid not exists', function (done) {
     (find as any)('port', 100000)
       .then(function (list: any[]) {


### PR DESCRIPTION
Started getting TS2345 Argument of type 'RegExp' is not assignable to parameter of type 'string | number' after updating to latest and using find-process with a RegExp like so:

```ts
findProcess('name', /someRegExp/)
```

Casting explicitly to 'any' works, but it would be nice if the type 'RegExp' be added as a possible type to the value (to be part of the union type). 

This PR

- adds 'RegExp' type to the type union of the value
- adds test case when passing a 'RegExp' as a value
- ensures options.strict is applied only when finding by name and passing a string value
