### PR TITLE
Add port-to-PID fallback chain with ss and lsof support

### DIFF
--- a/src/find_pid.ts
+++ b/src/find_pid.ts
@@ -14,168 +14,142 @@ const ensureDir = (path: string): Promise<void> => new Promise((resolve, reject)
   }
 })
 
-function findPidBySs(port: number, config: FindConfig): Promise<number> {
+/**
+ * Execute command and return stdout/stderr as a promise
+ */
+function execCmd(cmd: string, config: FindConfig): Promise<{ stdout: string, stderr: string }> {
   return new Promise((resolve, reject) => {
-    const cmd = 'ss -tunlp'
     utils.exec(cmd, function (err, stdout, stderr) {
       debugLog(!!config.debug, cmd, stdout || '', stderr || '')
       if (err) {
         reject(err)
-        return
+      } else {
+        resolve({ stdout: stdout.toString(), stderr: stderr.toString().trim() })
       }
-      const warn = stderr.toString().trim()
-      if (warn) {
-        log.warn(warn)
-      }
-
-      // strip header line
-      const data = utils.stripLine(stdout.toString(), 1)
-      // Columns: Netid(0) State(1) Recv-Q(2) Send-Q(3) Local Address:Port(4) Peer Address:Port(5) Process(6)
-      const columns = utils.extractColumns(data, [4, 6], 7).find(column => {
-        const matches = String(column[0]).match(/:(\d+)$/)
-        if (matches && matches[1] === String(port)) {
-          return true
-        }
-        return false
-      })
-
-      if (columns && columns[1]) {
-        const pidMatch = String(columns[1]).match(/pid=(\d+)/)
-        if (pidMatch) {
-          resolve(parseInt(pidMatch[1], 10))
-          return
-        }
-      }
-
-      reject(new Error(`pid of port (${port}) not found`))
     })
+  })
+}
+
+/**
+ * Check if column's address field ends with :port
+ */
+function matchPort(column: string[], port: number): boolean {
+  const matches = String(column[0]).match(/:(\d+)$/)
+  return matches != null && matches[1] === String(port)
+}
+
+function findPidBySs(port: number, config: FindConfig): Promise<number> {
+  return execCmd('ss -tunlp', config).then(({ stdout, stderr }) => {
+    if (stderr) {
+      log.warn(stderr)
+    }
+
+    // strip header line
+    // Columns: Netid(0) State(1) Recv-Q(2) Send-Q(3) Local Address:Port(4) Peer Address:Port(5) Process(6)
+    const data = utils.stripLine(stdout, 1)
+    const columns = utils.extractColumns(data, [4, 6], 7)
+      .find(column => matchPort(column, port))
+
+    if (columns && columns[1]) {
+      const pidMatch = String(columns[1]).match(/pid=(\d+)/)
+      if (pidMatch) {
+        return parseInt(pidMatch[1], 10)
+      }
+    }
+
+    throw new Error(`pid of port (${port}) not found`)
   })
 }
 
 function findPidByNetstatLinux(port: number, config: FindConfig): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const cmd = 'netstat -tunlp'
+  return execCmd('netstat -tunlp', config).then(({ stdout, stderr }) => {
+    if (stderr) {
+      // netstat -p ouputs warning if user is no-root
+      log.warn(stderr)
+    }
 
-    utils.exec(cmd, function (err, stdout, stderr) {
-      debugLog(!!config.debug, cmd, stdout || '', stderr || '')
-      if (err) {
-        reject(err)
-        return
-      }
-      const warn = stderr.toString().trim()
-      if (warn) {
-        // netstat -p ouputs warning if user is no-root
-        log.warn(warn)
-      }
+    // replace header
+    const data = utils.stripLine(stdout, 2)
+    const columns = utils.extractColumns(data, [3, 6], 7)
+      .find(column => matchPort(column, port))
 
-      // replace header
-      const data = utils.stripLine(stdout.toString(), 2)
-      const columns = utils.extractColumns(data, [3, 6], 7).find(column => {
-        const matches = String(column[0]).match(/:(\d+)$/)
+    if (columns && columns[1]) {
+      const pid = parseInt(columns[1].split('/', 1)[0], 10)
+
+      if (!isNaN(pid)) {
+        return pid
+      }
+    }
+
+    throw new Error(`pid of port (${port}) not found`)
+  })
+}
+
+function findPidByNetstatDarwin(port: number, config: FindConfig): Promise<number> {
+  return execCmd('netstat -anv -p TCP && netstat -anv -p UDP', config).then(({ stdout, stderr }) => {
+    if (stderr) {
+      log.warn(stderr)
+    }
+
+    // Drop group header, e.g. "Active Internet connections"
+    const table = utils.stripLine(stdout, 1)
+    // Get the next line with the column headers
+    const headers = table.slice(0, table.indexOf('\n'))
+    // Drop the header line to get the table body
+    const body = utils.stripLine(table, 1)
+
+    // In macOS >=Sequoia, columns include `rxbytes` and `txbytes`, which
+    // shifts the PID column to index 10. Detect this with a search
+    // for rxbytes. (Parsing the headers more robustly isn't possible
+    // because some colmn names contain spaces, and others are only separated
+    // by a single space.)
+    const pidColumn = headers.indexOf('rxbytes') >= 0 ? 10 : 8
+
+    const found = utils.extractColumns(body, [0, 3, pidColumn], 10)
+      .filter(row => {
+        return !!String(row[0]).match(/^(udp|tcp)/)
+      })
+      .find(row => {
+        const matches = String(row[1]).match(/\.(\d+)$/)
         if (matches && matches[1] === String(port)) {
           return true
         }
         return false
       })
 
-      if (columns && columns[1]) {
-        const pid = parseInt(columns[1].split('/', 1)[0], 10)
-
-        if (!isNaN(pid) && pid > 0) {
-          resolve(pid)
-          return
-        }
+    if (found && found[2].length) {
+      // PID column can be "pid" or "processname:pid"
+      const pidCell = String(found[2])
+      const pidMatch = pidCell.match(/:(\d+)$/)
+      const pid = pidMatch ? parseInt(pidMatch[1], 10) : parseInt(pidCell, 10)
+      if (!isNaN(pid)) {
+        return pid
       }
+    }
 
-      reject(new Error(`pid of port (${port}) not found`))
-    })
-  })
-}
-
-function findPidByNetstatDarwin(port: number, config: FindConfig): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const cmd = 'netstat -anv -p TCP && netstat -anv -p UDP'
-    utils.exec(cmd, function (err, stdout, stderr) {
-      debugLog(!!config.debug, cmd, stdout || '', stderr || '')
-      if (err) {
-        reject(err)
-        return
-      }
-      const stderrStr = stderr.toString().trim()
-      if (stderrStr) {
-        log.warn(stderrStr)
-      }
-
-      // Drop group header, e.g. "Active Internet connections"
-      const table = utils.stripLine(stdout.toString(), 1)
-      // Get the next line with the column headers
-      const headers = table.slice(0, table.indexOf('\n'))
-      // Drop the header line to get the table body
-      const body = utils.stripLine(table, 1)
-
-      // In macOS >=Sequoia, columns include `rxbytes` and `txbytes`, which
-      // shifts the PID column to index 10. Detect this with a search
-      // for rxbytes. (Parsing the headers more robustly isn't possible
-      // because some colmn names contain spaces, and others are only separated
-      // by a single space.)
-      const pidColumn = headers.indexOf('rxbytes') >= 0 ? 10 : 8
-
-      const found = utils.extractColumns(body, [0, 3, pidColumn], 10)
-        .filter(row => {
-          return !!String(row[0]).match(/^(udp|tcp)/)
-        })
-        .find(row => {
-          const matches = String(row[1]).match(/\.(\d+)$/)
-          if (matches && matches[1] === String(port)) {
-            return true
-          }
-          return false
-        })
-
-      if (found && found[2].length) {
-        // PID column can be "pid" or "processname:pid"
-        const pidCell = String(found[2])
-        const pidMatch = pidCell.match(/:(\d+)$/)
-        const pid = pidMatch ? parseInt(pidMatch[1], 10) : parseInt(pidCell, 10)
-        if (!isNaN(pid)) {
-          resolve(pid)
-          return
-        }
-      }
-
-      reject(new Error(`pid of port (${port}) not found`))
-    })
+    throw new Error(`pid of port (${port}) not found`)
   })
 }
 
 function findPidByLsof(port: number, config: FindConfig): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const cmd = `lsof -nP -i :${port}`
-    utils.exec(cmd, function (err, stdout, stderr) {
-      debugLog(!!config.debug, cmd, stdout || '', stderr || '')
-      if (err) {
-        reject(err)
-        return
-      }
-      const warn = stderr.toString().trim()
-      if (warn) {
-        log.warn(warn)
-      }
+  return execCmd(`lsof -nP -i :${port}`, config).then(({ stdout, stderr }) => {
+    if(stderr) {
+      log.warn(stderr)
+    }
 
-      // strip header line
-      const data = utils.stripLine(stdout.toString(), 1)
-      // lsof columns: COMMAND(0) PID(1) USER(2) ...
-      const columns = utils.extractColumns(data, [1], 2)
-      for (const col of columns) {
-        const pid = parseInt(col[0], 10)
-        if (!isNaN(pid) && pid > 0) {
-          resolve(pid)
-          return
-        }
-      }
+    // strip header line
+    // lsof columns: COMMAND(0) PID(1) USER(2) ...
+    const data = utils.stripLine(stdout, 1)
+    const columns = utils.extractColumns(data, [1], 2)
 
-      reject(new Error(`pid of port (${port}) not found`))
-    })
+    for (const col of columns) {
+      const pid = parseInt(col[0], 10)
+      if (!isNaN(pid)) {
+        return pid
+      }
+    }
+
+    throw new Error(`pid of port (${port}) not found`)
   })
 }
 
@@ -192,36 +166,21 @@ const finders: Record<string, (port: number, config: FindConfig) => Promise<numb
   },
 
   win32(port: number, config: FindConfig): Promise<number> {
-    return new Promise((resolve, reject) => {
-      const cmd = 'netstat -ano'
-      utils.exec(cmd, function (err, stdout, stderr) {
-        debugLog(!!config.debug, cmd, stdout || '', stderr || '')
-        if (err) {
-          reject(err)
-        } else {
-          const stderrStr = stderr.toString().trim()
-          if (stderrStr) {
-            reject(new Error(stderrStr))
-            return
-          }
+    return execCmd('netstat -ano', config).then(({ stdout, stderr }) => {
+      if (stderr) {
+        throw new Error(stderr)
+      }
 
-          // replace header
-          const data = utils.stripLine(stdout.toString(), 4)
-          const columns = utils.extractColumns(data, [1, 4], 5).find(column => {
-            const matches = String(column[0]).match(/:(\d+)$/)
-            if (matches && matches[1] === String(port)) {
-              return true
-            }
-            return false
-          })
+      // replace header
+      const data = utils.stripLine(stdout, 4)
+      const columns = utils.extractColumns(data, [1, 4], 5)
+        .find(column => matchPort(column, port))
 
-          if (columns && columns[1].length && parseInt(columns[1], 10) > 0) {
-            resolve(parseInt(columns[1], 10))
-          } else {
-            reject(new Error(`pid of port (${port}) not found`))
-          }
-        }
-      })
+      if (columns && columns[1].length && parseInt(columns[1], 10) > 0) {
+        return parseInt(columns[1], 10)
+      }
+
+      throw new Error(`pid of port (${port}) not found`)
     })
   },
 
@@ -246,13 +205,8 @@ const finders: Record<string, (port: number, config: FindConfig) => Promise<numb
               reject(err)
             } else {
               data = utils.stripLine(data, 2)
-              const columns = utils.extractColumns(data, [3, 6], 7).find(column => {
-                const matches = String(column[0]).match(/:(\d+)$/)
-                if (matches && matches[1] === String(port)) {
-                  return true
-                }
-                return false
-              })
+              const columns = utils.extractColumns(data, [3, 6], 7)
+                .find(column => matchPort(column, port))
 
               if (columns && columns[1]) {
                 const pid = columns[1].split('/', 1)[0]
@@ -290,4 +244,4 @@ function findPidByPort(port: number, config: FindConfig = {}): Promise<number> {
   })
 }
 
-export default findPidByPort 
+export default findPidByPort

--- a/src/find_pid.ts
+++ b/src/find_pid.ts
@@ -14,102 +14,181 @@ const ensureDir = (path: string): Promise<void> => new Promise((resolve, reject)
   }
 })
 
+function findPidBySs(port: number, config: FindConfig): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const cmd = 'ss -tunlp'
+    utils.exec(cmd, function (err, stdout, stderr) {
+      debugLog(!!config.debug, cmd, stdout || '', stderr || '')
+      if (err) {
+        reject(err)
+        return
+      }
+      const warn = stderr.toString().trim()
+      if (warn) {
+        log.warn(warn)
+      }
+
+      // strip header line
+      const data = utils.stripLine(stdout.toString(), 1)
+      // Columns: Netid(0) State(1) Recv-Q(2) Send-Q(3) Local Address:Port(4) Peer Address:Port(5) Process(6)
+      const columns = utils.extractColumns(data, [4, 6], 7).find(column => {
+        const matches = String(column[0]).match(/:(\d+)$/)
+        if (matches && matches[1] === String(port)) {
+          return true
+        }
+        return false
+      })
+
+      if (columns && columns[1]) {
+        const pidMatch = String(columns[1]).match(/pid=(\d+)/)
+        if (pidMatch) {
+          resolve(parseInt(pidMatch[1], 10))
+          return
+        }
+      }
+
+      reject(new Error(`pid of port (${port}) not found`))
+    })
+  })
+}
+
+function findPidByNetstatLinux(port: number, config: FindConfig): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const cmd = 'netstat -tunlp'
+
+    utils.exec(cmd, function (err, stdout, stderr) {
+      debugLog(!!config.debug, cmd, stdout || '', stderr || '')
+      if (err) {
+        reject(err)
+        return
+      }
+      const warn = stderr.toString().trim()
+      if (warn) {
+        // netstat -p ouputs warning if user is no-root
+        log.warn(warn)
+      }
+
+      // replace header
+      const data = utils.stripLine(stdout.toString(), 2)
+      const columns = utils.extractColumns(data, [3, 6], 7).find(column => {
+        const matches = String(column[0]).match(/:(\d+)$/)
+        if (matches && matches[1] === String(port)) {
+          return true
+        }
+        return false
+      })
+
+      if (columns && columns[1]) {
+        const pid = parseInt(columns[1].split('/', 1)[0], 10)
+
+        if (!isNaN(pid) && pid > 0) {
+          resolve(pid)
+          return
+        }
+      }
+
+      reject(new Error(`pid of port (${port}) not found`))
+    })
+  })
+}
+
+function findPidByNetstatDarwin(port: number, config: FindConfig): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const cmd = 'netstat -anv -p TCP && netstat -anv -p UDP'
+    utils.exec(cmd, function (err, stdout, stderr) {
+      debugLog(!!config.debug, cmd, stdout || '', stderr || '')
+      if (err) {
+        reject(err)
+        return
+      }
+      const stderrStr = stderr.toString().trim()
+      if (stderrStr) {
+        log.warn(stderrStr)
+      }
+
+      // Drop group header, e.g. "Active Internet connections"
+      const table = utils.stripLine(stdout.toString(), 1)
+      // Get the next line with the column headers
+      const headers = table.slice(0, table.indexOf('\n'))
+      // Drop the header line to get the table body
+      const body = utils.stripLine(table, 1)
+
+      // In macOS >=Sequoia, columns include `rxbytes` and `txbytes`, which
+      // shifts the PID column to index 10. Detect this with a search
+      // for rxbytes. (Parsing the headers more robustly isn't possible
+      // because some colmn names contain spaces, and others are only separated
+      // by a single space.)
+      const pidColumn = headers.indexOf('rxbytes') >= 0 ? 10 : 8
+
+      const found = utils.extractColumns(body, [0, 3, pidColumn], 10)
+        .filter(row => {
+          return !!String(row[0]).match(/^(udp|tcp)/)
+        })
+        .find(row => {
+          const matches = String(row[1]).match(/\.(\d+)$/)
+          if (matches && matches[1] === String(port)) {
+            return true
+          }
+          return false
+        })
+
+      if (found && found[2].length) {
+        // PID column can be "pid" or "processname:pid"
+        const pidCell = String(found[2])
+        const pidMatch = pidCell.match(/:(\d+)$/)
+        const pid = pidMatch ? parseInt(pidMatch[1], 10) : parseInt(pidCell, 10)
+        if (!isNaN(pid)) {
+          resolve(pid)
+          return
+        }
+      }
+
+      reject(new Error(`pid of port (${port}) not found`))
+    })
+  })
+}
+
+function findPidByLsof(port: number, config: FindConfig): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const cmd = `lsof -nP -i :${port}`
+    utils.exec(cmd, function (err, stdout, stderr) {
+      debugLog(!!config.debug, cmd, stdout || '', stderr || '')
+      if (err) {
+        reject(err)
+        return
+      }
+      const warn = stderr.toString().trim()
+      if (warn) {
+        log.warn(warn)
+      }
+
+      // strip header line
+      const data = utils.stripLine(stdout.toString(), 1)
+      // lsof columns: COMMAND(0) PID(1) USER(2) ...
+      const columns = utils.extractColumns(data, [1], 2)
+      for (const col of columns) {
+        const pid = parseInt(col[0], 10)
+        if (!isNaN(pid) && pid > 0) {
+          resolve(pid)
+          return
+        }
+      }
+
+      reject(new Error(`pid of port (${port}) not found`))
+    })
+  })
+}
+
 const finders: Record<string, (port: number, config: FindConfig) => Promise<number>> = {
   darwin(port: number, config: FindConfig): Promise<number> {
-    return new Promise((resolve, reject) => {
-      const cmd = 'netstat -anv -p TCP && netstat -anv -p UDP'
-      utils.exec(cmd, function (err, stdout, stderr) {
-        debugLog(!!config.debug, cmd, stdout || '', stderr || '')
-        if (err) {
-          reject(err)
-        } else {
-          const stderrStr = stderr.toString().trim()
-          if (stderrStr) {
-            reject(new Error(stderrStr))
-            return
-          }
-
-          // Drop group header, e.g. "Active Internet connections"
-          const table = utils.stripLine(stdout.toString(), 1)
-          // Get the next line with the column headers
-          const headers = table.slice(0, table.indexOf('\n'))
-          // Drop the header line to get the table body
-          const body = utils.stripLine(table, 1)
-
-          // In macOS >=Sequoia, columns include `rxbytes` and `txbytes`, which
-          // shifts the PID column to index 10. Detect this with a search
-          // for rxbytes. (Parsing the headers more robustly isn't possible
-          // because some colmn names contain spaces, and others are only separated
-          // by a single space.)
-          const pidColumn = headers.indexOf('rxbytes') >= 0 ? 10 : 8
-
-          const found = utils.extractColumns(body, [0, 3, pidColumn], 10)
-            .filter(row => {
-              return !!String(row[0]).match(/^(udp|tcp)/)
-            })
-            .find(row => {
-              const matches = String(row[1]).match(/\.(\d+)$/)
-              if (matches && matches[1] === String(port)) {
-                return true
-              }
-              return false
-            })
-
-          if (found && found[2].length) {
-            // PID column can be "pid" or "processname:pid"
-            const pidCell = String(found[2])
-            const pidMatch = pidCell.match(/:(\d+)$/)
-            const pid = pidMatch ? parseInt(pidMatch[1], 10) : parseInt(pidCell, 10)
-            if (!isNaN(pid)) {
-              resolve(pid)
-            } 
-          } 
-
-          reject(new Error(`pid of port (${port}) not found`))
-        }
-      })
-    })
+    return findPidByNetstatDarwin(port, config)
+      .catch(() => findPidByLsof(port, config))
   },
 
   linux(port: number, config: FindConfig): Promise<number> {
-    return new Promise((resolve, reject) => {
-      const cmd = 'netstat -tunlp'
-
-      utils.exec(cmd, function (err, stdout, stderr) {
-        debugLog(!!config.debug, cmd, stdout || '', stderr || '')
-        if (err) {
-          reject(err)
-        } else {
-          const warn = stderr.toString().trim()
-          if (warn) {
-            // netstat -p ouputs warning if user is no-root
-            log.warn(warn)
-          }
-
-          // replace header
-          const data = utils.stripLine(stdout.toString(), 2)
-          const columns = utils.extractColumns(data, [3, 6], 7).find(column => {
-            const matches = String(column[0]).match(/:(\d+)$/)
-            if (matches && matches[1] === String(port)) {
-              return true
-            }
-            return false
-          })
-
-          if (columns && columns[1]) {
-            const pid = columns[1].split('/', 1)[0]
-
-            if (pid.length) {
-              resolve(parseInt(pid, 10))
-            } else {
-              reject(new Error(`pid of port (${port}) not found`))
-            }
-          } else {
-            reject(new Error(`pid of port (${port}) not found`))
-          }
-        }
-      })
-    })
+    return findPidBySs(port, config)
+      .catch(() => findPidByNetstatLinux(port, config))
+      .catch(() => findPidByLsof(port, config))
   },
 
   win32(port: number, config: FindConfig): Promise<number> {

--- a/test/find_pid.test.ts
+++ b/test/find_pid.test.ts
@@ -1,0 +1,194 @@
+import assert from 'assert'
+import utils from '../src/utils'
+import findPidByPort from '../src/find_pid'
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
+
+const originalExec = utils.exec
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+const NOT_FOUND = { error: new Error('command not found') }
+
+// Headers matching real command output (stripped during parsing, but must be present)
+const SS_HDR = 'Netid State  Recv-Q Send-Q   Local Address:Port   Peer Address:Port Process\n'
+const NETSTAT_LINUX_HDR =
+  'Active Internet connections (only servers)\n' +
+  'Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name\n'
+const NETSTAT_DARWIN_HDR =
+  'Active Internet connections (including servers)\n' +
+  'Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)     rhiwat shiwat    pid   epid\n'
+const NETSTAT_SEQUOIA_HDR =
+  'Active Internet connections (including servers)\n' +
+  'Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)     rhiwat shiwat  rxbytes  txbytes    pid   epid\n'
+const LSOF_HDR = 'COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\n'
+const NETSTAT_WIN32_HDR =
+  '\r\nActive Connections\r\n\r\n' +
+  '  Proto  Local Address          Foreign Address        State           PID\r\n'
+
+function mockExec(responses: Record<string, { stdout?: string; stderr?: string; error?: Error }>) {
+  utils.exec = function (cmd: string, callback: ExecCallback) {
+    for (const [pattern, resp] of Object.entries(responses)) {
+      if (cmd.includes(pattern)) {
+        if (resp.error) {
+          callback(resp.error, '', resp.stderr || '')
+        } else {
+          callback(null, resp.stdout || '', resp.stderr || '')
+        }
+        return
+      }
+    }
+    callback(new Error(`Command not mocked: ${cmd}`), '', '')
+  } as any
+}
+
+function setPlatform(platform: string) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+describe('findPidByPort fallback logic', function () {
+  afterEach(function () {
+    utils.exec = originalExec
+    Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  describe('Linux', function () {
+    beforeEach(function () { setPlatform('linux') })
+
+    it('ss succeeds', function () {
+      mockExec({
+        'ss -tunlp': { stdout: SS_HDR + 'tcp   LISTEN 0 128 0.0.0.0:3000 0.0.0.0:* users:(("node",pid=1234,fd=19))\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 1234))
+    })
+
+    it('ss with IPv6 address', function () {
+      mockExec({
+        'ss -tunlp': { stdout: SS_HDR + 'tcp   LISTEN 0 128 [::]:3000 [::]:* users:(("node",pid=4321,fd=19))\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 4321))
+    })
+
+    it('ss fails → netstat succeeds', function () {
+      mockExec({
+        'ss -tunlp': NOT_FOUND,
+        'netstat -tunlp': { stdout: NETSTAT_LINUX_HDR + 'tcp   0   0 0.0.0.0:3000   0.0.0.0:*   LISTEN   5678/node\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 5678))
+    })
+
+    it('ss + netstat fail → lsof succeeds', function () {
+      mockExec({
+        'ss -tunlp': NOT_FOUND,
+        'netstat -tunlp': NOT_FOUND,
+        'lsof -nP -i :3000': { stdout: LSOF_HDR + 'node   9999 user  19u  IPv4 12345  0t0  TCP *:3000 (LISTEN)\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 9999))
+    })
+
+    it('permission issues (no PID visible) → falls through to lsof', function () {
+      mockExec({
+        'ss -tunlp': { stdout: SS_HDR + 'tcp   LISTEN 0 128 0.0.0.0:3000 0.0.0.0:*\n' },
+        'netstat -tunlp': {
+          stdout: NETSTAT_LINUX_HDR + 'tcp   0   0 0.0.0.0:3000   0.0.0.0:*   LISTEN   -\n',
+          stderr: '(Not all processes could be identified)'
+        },
+        'lsof -nP -i :3000': { stdout: LSOF_HDR + 'node   7777 user  19u  IPv4 12345  0t0  TCP *:3000 (LISTEN)\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 7777))
+    })
+
+    it('all three fail → rejects', function () {
+      mockExec({ 'ss -tunlp': NOT_FOUND, 'netstat -tunlp': NOT_FOUND, 'lsof -nP -i :3000': NOT_FOUND })
+      return assert.rejects(findPidByPort(3000))
+    })
+
+    it('lsof returns first PID from multiple rows', function () {
+      mockExec({
+        'ss -tunlp': NOT_FOUND,
+        'netstat -tunlp': NOT_FOUND,
+        'lsof -nP -i :3000': {
+          stdout: LSOF_HDR +
+            'node   1111 user  19u  IPv4 12345  0t0  TCP *:3000 (LISTEN)\n' +
+            'node   2222 user  20u  IPv4 12346  0t0  TCP 127.0.0.1:3000 (LISTEN)\n'
+        }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 1111))
+    })
+
+    it('lsof header-only output → rejects', function () {
+      mockExec({ 'ss -tunlp': NOT_FOUND, 'netstat -tunlp': NOT_FOUND, 'lsof -nP -i :3000': { stdout: LSOF_HDR } })
+      return assert.rejects(findPidByPort(3000))
+    })
+  })
+
+  describe('macOS (darwin)', function () {
+    beforeEach(function () { setPlatform('darwin') })
+
+    it('netstat succeeds', function () {
+      mockExec({
+        'netstat -anv': { stdout: NETSTAT_DARWIN_HDR + 'tcp4   0   0  *.3000   *.*   LISTEN   131072 131072   2222   0\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 2222))
+    })
+
+    it('netstat Sequoia format (rxbytes)', function () {
+      mockExec({
+        'netstat -anv': { stdout: NETSTAT_SEQUOIA_HDR + 'tcp4   0   0  *.3000   *.*   LISTEN   131072 131072   0   0   3333   0\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 3333))
+    })
+
+    it('netstat fails → lsof succeeds', function () {
+      mockExec({
+        'netstat -anv': NOT_FOUND,
+        'lsof -nP -i :3000': { stdout: LSOF_HDR + 'node   8888 user  19u  IPv4 12345  0t0  TCP *:3000 (LISTEN)\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 8888))
+    })
+
+    it('netstat no match → lsof succeeds', function () {
+      mockExec({
+        'netstat -anv': { stdout: NETSTAT_DARWIN_HDR },
+        'lsof -nP -i :3000': { stdout: LSOF_HDR + 'node   6666 user  19u  IPv4 12345  0t0  TCP *:3000 (LISTEN)\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 6666))
+    })
+
+    it('netstat with processname:pid format', function () {
+      mockExec({
+        'netstat -anv': { stdout: NETSTAT_DARWIN_HDR + 'tcp4   0   0  *.3000   *.*   LISTEN   131072 131072   node:2222   0\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 2222))
+    })
+
+    it('both fail → rejects', function () {
+      mockExec({ 'netstat -anv': NOT_FOUND, 'lsof -nP -i :3000': NOT_FOUND })
+      return assert.rejects(findPidByPort(3000))
+    })
+  })
+
+  describe('Windows', function () {
+    beforeEach(function () { setPlatform('win32') })
+
+    it('netstat -ano succeeds', function () {
+      mockExec({
+        'netstat -ano': { stdout: NETSTAT_WIN32_HDR + '  TCP    0.0.0.0:3000   0.0.0.0:0   LISTENING   4444\r\n' }
+      })
+      return findPidByPort(3000).then(pid => assert.strictEqual(pid, 4444))
+    })
+
+    it('netstat -ano stderr → rejects', function () {
+      mockExec({
+        'netstat -ano': { stdout: '', stderr: 'access denied' }
+      })
+      return assert.rejects(findPidByPort(3000), /access denied/)
+    })
+
+    it('netstat -ano no match → rejects', function () {
+      mockExec({
+        'netstat -ano': { stdout: NETSTAT_WIN32_HDR + '  TCP    0.0.0.0:8080   0.0.0.0:0   LISTENING   5555\r\n' }
+      })
+      return assert.rejects(findPidByPort(3000))
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `ss` and `lsof` as fallback tools for port-to-PID resolution
- Linux: `ss -tunlp` → `netstat -tunlp` → `lsof -nP -i :<port>`
- macOS/FreeBSD/SunOS: `netstat -anv` → `lsof -nP -i :<port>`
- Windows and Android: unchanged
- Fix existing bug where `netstat` on Linux resolves with `NaN` when PID field is `-` (non-root)
- Fix existing bug where `netstat` stderr on macOS rejects instead of allowing fallback
- Extract `execCmd` and `matchPort` helpers to reduce boilerplate across all platform finders

The first commit introduces the fallback logic + tests while the second commit is just refactoring some code

## Motivation

`netstat` is deprecated on many Linux distros in favor of `ss`, and running without root often produces empty PID fields. This change adds a try-and-fallback chain so port lookup works in more environments without requiring any specific tool to be installed.
